### PR TITLE
fix(plugin_toc): remove extra escape char

### DIFF
--- a/crates/plugin_toc/src/lib.rs
+++ b/crates/plugin_toc/src/lib.rs
@@ -48,7 +48,6 @@ pub fn collect_title_in_mdast(heading: &mut Heading) -> (String, String) {
       _ => continue, // Continue if node is not Text or Code
     }
   }
-  title = title.replace("\"", "\\\"").replace("'", "\\\'");
   (title, custom_id)
 }
 


### PR DESCRIPTION
fix https://github.com/web-infra-dev/rspress/issues/320