### PR TITLE
chore: release 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.3](https://github.com/web-infra-dev/mdx-rs/compare/v0.5.2...v0.5.3) (2024-04-28)
+
+
+
 ## [0.5.2](https://github.com/web-infra-dev/mdx-rs/compare/v0.5.1...v0.5.2) (2024-04-25)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rspress/mdx-rs",
   "description": "MDX compilation binding for Rspress",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {


### PR DESCRIPTION
fix 0.5.2 x86_macos binaray package missing problem

<img width="400" src="https://github.com/web-infra-dev/mdx-rs/assets/79413249/6e32eed8-fce9-4273-8841-10326d02c4bd" />
