### PR TITLE
feat: add auto highlighter plugin and follow some advice from the rust-analyzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdx_plugin_highlighter"
+version = "0.1.0"
+dependencies = [
+ "markdown",
+]
+
+[[package]]
 name = "mdx_plugin_html"
 version = "0.1.0"
 dependencies = [
@@ -560,6 +567,7 @@ dependencies = [
  "mdx_plugin_external_link",
  "mdx_plugin_frontmatter",
  "mdx_plugin_header_anchor",
+ "mdx_plugin_highlighter",
  "mdx_plugin_html",
  "mdx_plugin_normalize_link",
  "mdx_plugin_toc",

--- a/crates/binding/src/lib.rs
+++ b/crates/binding/src/lib.rs
@@ -27,6 +27,7 @@ pub struct Output {
   pub html: String,
   pub title: String,
   pub toc: Vec<Toc>,
+  pub languages: Vec<String>,
   pub frontmatter: String,
 }
 
@@ -56,6 +57,7 @@ impl From<CompileResult> for Output {
       html: res.html,
       title: res.title,
       toc: res.toc.into_iter().map(|item| item.into()).collect(),
+      languages: res.languages,
       frontmatter: res.frontmatter,
     }
   }
@@ -83,6 +85,7 @@ impl Task for Compiler {
         .map(|item| item.into())
         .collect::<Vec<Toc>>(),
     )?;
+    obj.set_named_property("languages", output.languages)?;
     obj.set_named_property("frontmatter", output.frontmatter)?;
     Ok(obj)
   }

--- a/crates/mdx_rs/Cargo.toml
+++ b/crates/mdx_rs/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 mdx_plugin_code_block = { path = "../plugin_code_block" }
+mdx_plugin_highlighter = { path = "../plugin_highlighter" }
 mdx_plugin_container = { path = "../plugin_container" }
 mdx_plugin_external_link = { path = "../plugin_external_link" }
 mdx_plugin_frontmatter = { path = "../plugin_frontmatter" }

--- a/crates/mdx_rs/src/mdx_plugin_recma_jsx_rewrite.rs
+++ b/crates/mdx_rs/src/mdx_plugin_recma_jsx_rewrite.rs
@@ -463,7 +463,7 @@ impl<'a> State<'a> {
 
     // Add statements to functions.
     if !statements.is_empty() {
-      let mut body: &mut BlockStmt = match func {
+      let body: &mut BlockStmt = match func {
         Func::Expr(expr) => {
           // Always exists if we have components in it.
           expr.function.body.as_mut().unwrap()

--- a/crates/plugin_highlighter/.gitignore
+++ b/crates/plugin_highlighter/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/crates/plugin_highlighter/Cargo.toml
+++ b/crates/plugin_highlighter/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "mdx_plugin_highlighter"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+markdown = { workspace = true }

--- a/crates/plugin_highlighter/src/lib.rs
+++ b/crates/plugin_highlighter/src/lib.rs
@@ -1,0 +1,46 @@
+//! Author: shulaoda
+//!
+//! This plugin is used to collect code lang in mdx.
+
+use markdown::mdast::Node;
+use std::collections::HashSet;
+
+pub fn mdx_plugin_highlighter(node: &Node) -> Vec<String> {
+  let mut languages: HashSet<String> = HashSet::new();
+
+  if let Node::Root(root) = node {
+    for child in &root.children {
+      if let Node::Code(code) = child {
+        if let Some(lang) = &code.lang {
+          languages.insert(lang.clone());
+        }
+      }
+    }
+  }
+
+  languages.into_iter().collect::<Vec<String>>()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use markdown::mdast;
+
+  #[test]
+  fn test_mdx_plugin_highlighter() {
+    let mut code = mdast::Node::Root(mdast::Root {
+      children: vec![mdast::Node::Code(mdast::Code {
+        lang: Some("markdown".into()),
+        meta: None,
+        value: "".into(),
+        position: None,
+      })],
+      position: None,
+    });
+
+    assert_eq!(
+      mdx_plugin_highlighter(&mut code),
+      vec!["markdown".to_string()]
+    );
+  }
+}

--- a/crates/plugin_highlighter/src/lib.rs
+++ b/crates/plugin_highlighter/src/lib.rs
@@ -28,7 +28,7 @@ mod tests {
 
   #[test]
   fn test_mdx_plugin_highlighter() {
-    let mut code = mdast::Node::Root(mdast::Root {
+    let code = mdast::Node::Root(mdast::Root {
       children: vec![mdast::Node::Code(mdast::Code {
         lang: Some("markdown".into()),
         meta: None,
@@ -39,7 +39,7 @@ mod tests {
     });
 
     assert_eq!(
-      mdx_plugin_highlighter(&mut code),
+      mdx_plugin_highlighter(&code),
       vec!["markdown".to_string()]
     );
   }

--- a/crates/plugin_html/src/lib.rs
+++ b/crates/plugin_html/src/lib.rs
@@ -51,9 +51,9 @@ pub fn mdx_plugin_html(node: &Node) -> String {
   mdx_plugin_html_impl(node)
 }
 
+#[cfg(test)]
 mod tests {
   use super::*;
-  use hast::Node;
 
   #[test]
   fn test_serialize_hast_to_html() {

--- a/crates/plugin_toc/src/lib.rs
+++ b/crates/plugin_toc/src/lib.rs
@@ -7,7 +7,7 @@
 
 use markdown::mdast::{self, Heading};
 use slugger::Slugger;
-use std::{fmt::format, vec};
+use std::vec;
 use utils::extract_title_and_id;
 
 #[derive(Debug, Clone)]

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ export interface Output {
   html: string
   title: string
   toc: Array<Toc>
+  languages: Array<string>
   frontmatter: string
 }
 export interface CompileOptions {


### PR DESCRIPTION
This plugin is very simple, just to solve this issue [web-infra-dev/rspress#1043](https://github.com/web-infra-dev/rspress/issues/1043). I think putting it in `plugin_toc` may avoid an unnecessary loop operation, but in the end, I decided to add a plugin for future maintenance.
In addition, I also removed some unnecessary code based on the prompts from the `rust-analyzer`.