### PR TITLE
feat(plugin_container): support for GitHub markdown alerts syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,4 @@ $RECYCLE.BIN/
 
 *.node
 .vscode
+.idea

--- a/__test__/__snapshots__/index.spec.ts.snap
+++ b/__test__/__snapshots__/index.spec.ts.snap
@@ -438,6 +438,12 @@ exports[`compile > should render container type correctly 1`] = `
     <p>This is a <code>block</code> of type <code>danger</code></p>
   </div>
 </div>
+<details>
+  <summary>DETAILS</summary>
+  <div>
+    <p>This is a <code>block</code> of type <code>details</code></p>
+  </div>
+</details>
 "
 `;
 
@@ -449,6 +455,8 @@ function _createMdxContent(props) {
       div: "div",
       p: "p",
       code: "code",
+      details: "details",
+      summary: "summary",
     },
     _provideComponents(),
     props.components
@@ -544,6 +552,21 @@ function _createMdxContent(props) {
           </_components.p>
         </_components.div>
       </_components.div>
+      {"\\n"}
+      <_components.details className="rspress-directive details">
+        <_components.summary className="rspress-directive-title">
+          {"DETAILS"}
+        </_components.summary>
+        <_components.div className="rspress-directive-content">
+          <_components.p>
+            {"This is a "}
+            <_components.code>{"block"}</_components.code>
+            {" of type "}
+            <_components.code>{"details"}</_components.code>
+            {"\\n"}
+          </_components.p>
+        </_components.div>
+      </_components.details>
     </>
   );
 }
@@ -729,6 +752,160 @@ function _createMdxContent(props) {
           </_components.p>
         </_components.div>
       </_components.div>
+    </>
+  );
+}
+function MDXContent(props = {}) {
+  const { wrapper: MDXLayout } = Object.assign(
+    {},
+    _provideComponents(),
+    props.components
+  );
+  return MDXLayout ? (
+    <MDXLayout {...props}>
+      <_createMdxContent {...props} />
+    </MDXLayout>
+  ) : (
+    _createMdxContent(props)
+  );
+}
+export default MDXContent;
+"
+`;
+
+exports[`compile > should render github alerts correctly 1`] = `
+"<div>
+  <div>TIP</div>
+  <div>
+    <p>
+      <strong>Helpful advice for doing things better or more easily.</strong>
+    </p>
+  </div>
+</div>
+<div>
+  <div>NOTE</div>
+  <div>
+    <h1>Please read this note!</h1>
+  </div>
+</div>
+<div>
+  <div>WARNING</div>
+  <div>
+    <p>Use <code>dummy</code> instead of <code>demo</code></p>
+  </div>
+</div>
+<div>
+  <div>CAUTION</div>
+  <div>
+    <p>Use this code:-</p>
+    <pre><code>console.log(69);
+</code></pre>
+  </div>
+</div>
+<details>
+  <summary>DETAILS</summary>
+  <div>
+    <p>This is a <code>block</code> of type <code>details</code></p>
+  </div>
+</details>
+"
+`;
+
+exports[`compile > should render github alerts correctly 2`] = `
+"import { useMDXComponents as _provideComponents } from "@mdx-js/react";
+function _createMdxContent(props) {
+  const _components = Object.assign(
+    {
+      div: "div",
+      p: "p",
+      strong: "strong",
+      h1: "h1",
+      code: "code",
+      pre: "pre",
+      details: "details",
+      summary: "summary",
+    },
+    _provideComponents(),
+    props.components
+  );
+  return (
+    <>
+      <_components.div className="rspress-directive TIP">
+        <_components.div className="rspress-directive-title">
+          {"TIP"}
+        </_components.div>
+        <_components.div className="rspress-directive-content">
+          {"\\n"}
+          <_components.p>
+            <_components.strong>
+              {"Helpful advice for doing things better or more easily."}
+            </_components.strong>
+          </_components.p>
+          {"\\n"}
+        </_components.div>
+      </_components.div>
+      {"\\n"}
+      <_components.div className="rspress-directive NOTE">
+        <_components.div className="rspress-directive-title">
+          {"NOTE"}
+        </_components.div>
+        <_components.div className="rspress-directive-content">
+          {"\\n"}
+          {"\\n"}
+          <_components.h1>{"Please read this note!"}</_components.h1>
+          {"\\n"}
+        </_components.div>
+      </_components.div>
+      {"\\n"}
+      <_components.div className="rspress-directive warning">
+        <_components.div className="rspress-directive-title">
+          {"WARNING"}
+        </_components.div>
+        <_components.div className="rspress-directive-content">
+          {"\\n"}
+          <_components.p>
+            {"Use "}
+            <_components.code>{"dummy"}</_components.code>
+            {" instead of "}
+            <_components.code>{"demo"}</_components.code>
+          </_components.p>
+          {"\\n"}
+        </_components.div>
+      </_components.div>
+      {"\\n"}
+      <_components.div className="rspress-directive CAUTION">
+        <_components.div className="rspress-directive-title">
+          {"CAUTION"}
+        </_components.div>
+        <_components.div className="rspress-directive-content">
+          {"\\n"}
+          {"\\n"}
+          <_components.p>{"Use this code:-"}</_components.p>
+          {"\\n"}
+          <_components.pre>
+            <_components.code className="language-javascript">
+              {"console.log(69);\\n"}
+            </_components.code>
+          </_components.pre>
+          {"\\n"}
+        </_components.div>
+      </_components.div>
+      {"\\n"}
+      <_components.details className="rspress-directive details">
+        <_components.summary className="rspress-directive-title">
+          {"DETAILS"}
+        </_components.summary>
+        <_components.div className="rspress-directive-content">
+          {"\\n"}
+          <_components.p>
+            {"This is a "}
+            <_components.code>{"block"}</_components.code>
+            {" of type "}
+            <_components.code>{"details"}</_components.code>
+          </_components.p>
+          {"\\n"}
+        </_components.div>
+      </_components.details>
     </>
   );
 }

--- a/__test__/container-type.md
+++ b/__test__/container-type.md
@@ -21,3 +21,7 @@ This is a `block` of type `danger`
 :::caution
 This is a `block` of type `danger`
 :::
+
+:::details
+This is a `block` of type `details`
+:::

--- a/__test__/github-alert-syntax.md
+++ b/__test__/github-alert-syntax.md
@@ -1,0 +1,19 @@
+> [!TIP]
+> **Helpful advice for doing things better or more easily.**
+
+> [!NOTE]
+>
+> # Please read this note!
+
+> [!warning]
+> Use `dummy` instead of `demo`
+
+> [!CAUTION]
+>
+> Use this code:-
+> ```javascript
+> console.log(69);
+> ```
+
+> [!details]
+> This is a `block` of type `details`

--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -107,4 +107,19 @@ describe("compile", () => {
     expect(html).toMatchSnapshot();
     expect(result).toMatchSnapshot();
   });
+
+  test("should render github alerts correctly", async () => {
+    const { code: result, html } = await testCompile({
+      value: readFileSync(
+          path.join(__dirname, "./github-alert-syntax.md"),
+          "utf8",
+      ),
+      filepath: "xxx.mdx",
+      development: true,
+      root: "xxx",
+    });
+
+    expect(html).toMatchSnapshot();
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/crates/plugin_container/src/lib.rs
+++ b/crates/plugin_container/src/lib.rs
@@ -59,8 +59,12 @@ fn create_new_container_node(
     container_title.to_string()
   };
 
+  let is_details = container_type == "details";
+  let title_tag_name = if is_details { "summary" } else { "div" };
+  let root_tag_name = if is_details { "details" } else { "div" };
+
   let container_title_node = hast::Element {
-    tag_name: "div".into(),
+    tag_name: title_tag_name.into(),
     properties: vec![(
       "className".into(),
       hast::PropertyValue::SpaceSeparated(vec!["rspress-directive-title".into()]),
@@ -81,7 +85,7 @@ fn create_new_container_node(
     position: None,
   };
   hast::Node::Element(hast::Element {
-    tag_name: "div".into(),
+    tag_name: root_tag_name.into(),
     properties: vec![(
       "className".into(),
       hast::PropertyValue::SpaceSeparated(vec!["rspress-directive".into(), container_type.into()]),
@@ -110,6 +114,61 @@ fn wrap_node_with_paragraph(
   hast::Node::Element(paragraph)
 }
 
+fn is_valid_container_type(container_type: &String) -> bool {
+  let mut container_type = container_type.clone();
+  container_type.make_ascii_lowercase();
+  let valid_types = [
+    "tip", "note", "warning", "caution", "danger", "info", "details",
+  ];
+  valid_types.contains(&container_type.as_str())
+}
+
+fn parse_github_alerts_container_meta(meta: &str) -> (String, String) {
+  // GitHub Alert's verification is very strict.
+  // space and breaks are not allowed, they must be a whole.
+  // but can remove spaces or breaks at the beginning and end.
+  let mut lines = meta.lines();
+
+  let mut container_type = String::new();
+  let mut remaining_data = String::new();
+
+  let mut is_first_line = true;
+
+  while let Some(line) = lines.next() {
+    // clear breaks if no container_type
+    if container_type.is_empty() && line.is_empty() {
+      continue;
+    }
+
+    if container_type.is_empty() && is_first_line {
+      is_first_line = false;
+
+      let split_line = line.trim().split_once("]");
+
+      container_type = split_line
+        .unwrap_or(("", ""))
+        .0
+        .to_owned()
+        .replace("[!", "");
+      remaining_data = split_line.unwrap_or(("", "")).1.to_owned();
+
+      if container_type.is_empty() {
+        break;
+      }
+
+      continue;
+    }
+
+    if remaining_data.is_empty() {
+      remaining_data = line.to_owned();
+    } else {
+      remaining_data = format!("{}\n{}", remaining_data, line);
+    }
+  }
+
+  (container_type, remaining_data)
+}
+
 fn traverse_children(root: &mut hast::Root) {
   let mut container_type = String::new();
   let mut container_title = String::new();
@@ -123,32 +182,92 @@ fn traverse_children(root: &mut hast::Root) {
     let child = &root.children[index];
     if let hast::Node::Element(element) = child {
       // Meet the start of the container
-      if element.tag_name == "p" && !container_content_start {
-        if let Some(hast::Node::Text(text)) = element.children.first() {
-          if text.value.starts_with(":::") {
-            (container_type, container_title) = parse_container_meta(&text.value);
-            // If the second element is MdxExpression, we parse the value and reassign the container_title
-            if let Some(hast::Node::MdxExpression(expression)) = element.children.get(1) {
-              container_title = parse_title_from_meta(&expression.value);
-            }
-            container_content_start = true;
-            container_content_start_index = index;
-            // :::tip\nThis is a tip
-            // We should record the `This is a tip`
-            for line in text.value.lines().skip(1) {
-              if line.ends_with(":::") {
-                container_content_end = true;
-                container_content_end_index = index;
-                break;
-              };
+      if !container_content_start {
+        // e.g. :::tip
+        if element.tag_name == "p" {
+          if let Some(hast::Node::Text(text)) = element.children.first() {
+            if text.value.starts_with(":::") {
+              (container_type, container_title) = parse_container_meta(&text.value);
+              if !is_valid_container_type(&container_type) {
+                index += 1;
+                continue;
+              }
+              // If the second element is MdxExpression, we parse the value and reassign the container_title
+              if let Some(hast::Node::MdxExpression(expression)) = element.children.get(1) {
+                container_title = parse_title_from_meta(&expression.value);
+              }
+              container_content_start = true;
+              container_content_start_index = index;
+              // :::tip\nThis is a tip
+              // We should record the `This is a tip`
+              for line in text.value.lines().skip(1) {
+                if line.ends_with(":::") {
+                  container_content_end = true;
+                  container_content_end_index = index;
+                  break;
+                };
 
-              container_content.push(wrap_node_with_paragraph(
-                &element.properties.clone(),
-                &[hast::Node::Text(hast::Text {
-                  value: line.into(),
-                  position: None,
-                })],
-              ));
+                container_content.push(wrap_node_with_paragraph(
+                  &element.properties.clone(),
+                  &[hast::Node::Text(hast::Text {
+                    value: line.into(),
+                    position: None,
+                  })],
+                ));
+              }
+            }
+          }
+        }
+        // e.g. > [!tip]
+        if element.tag_name == "blockquote" {
+          // why use element.children.get(1)?
+          // in crates/mdx_rs/mdast_util_to_hast.rs, method `transform_block_quote`
+          // always insert Text { value: "\n".into(),  position: None } in blockquote's children
+          if let Some(hast::Node::Element(first_element)) = element.children.get(1) {
+            if first_element.tag_name == "p" {
+              if let Some(hast::Node::Text(text)) = first_element.children.first() {
+                if text.value.trim().starts_with("[!") {
+                  // split data if previous step parse in one line
+                  // e.g <p>[!TIP] this is a tip</p>
+                  let (self_container_type, remaining_data) = parse_github_alerts_container_meta(&text.value);
+                  if !is_valid_container_type(&self_container_type) {
+                    index += 1;
+                    continue;
+                  }
+                  // in this case, container_type as container_title
+                  container_type = self_container_type.clone();
+                  container_title = self_container_type.clone();
+                  container_title.make_ascii_uppercase();
+
+                  container_content_start = true;
+                  container_content_start_index = index;
+
+                  // reform paragraph tag
+                  let mut paragraph_children = first_element.children.clone();
+                  if remaining_data.len() > 0 {
+                    paragraph_children[0] = hast::Node::Text(hast::Text {
+                      value: remaining_data.into(),
+                      position: None,
+                    })
+                  } else {
+                    paragraph_children.remove(0);
+                  }
+                  // reform blockquote tag
+                  let mut children = element.children.clone();
+
+                  if paragraph_children.is_empty() {
+                    children.remove(1);
+                  } else {
+                    children[1] =
+                      wrap_node_with_paragraph(&element.properties.clone(), &paragraph_children)
+                  }
+
+                  container_content = children;
+
+                  container_content_end = true;
+                  container_content_end_index = index;
+                }
+              }
             }
           }
         }
@@ -247,17 +366,22 @@ fn traverse_children(root: &mut hast::Root) {
 }
 
 pub fn mdx_plugin_container(root: &mut hast::Node) {
-  // Traverse children, get all p tags, check if they start with :::
+  // 1. Traverse children, get all p tags, check if they start with :::
   // If it is, it is regarded as container syntax, and the content from the beginning of ::: to the end of a certain ::: is regarded as a container
-  // The element of this container is a div element, className is "rspress-container"
+  // 2. Traverse children, get all blockquote tags, check if they next child's first element is p tags and if start with [! and end of ]
+  // If it is, it is regarded as container syntax, and the content from the beginning of blockquote to the end of a certain blockquote is regarded as a container
+  // The element of this container is a div element, className is "rspress-directive"
   // for example:
   // :::tip
   // this is a tip
   // :::
+  // or
+  // > [!tip]
+  // > this is a tip
   // Will be transformed to:
-  // <div class="rspress-container">
-  //   <div class="rspress-container-title">tip</div>
-  //   <div class="rspress-container-content">
+  // <div class="rspress-directive">
+  //   <div class="rspress-directive-title">tip</div>
+  //   <div class="rspress-directive-content">
   //     <p>This is a tip</p>
   //   </div>
   // </div>
@@ -612,6 +736,13 @@ mod tests {
     );
   }
 
+ #[test]
+ fn test_parse_github_alerts_container_meta() {
+  assert_eq!(parse_github_alerts_container_meta("[!TIP]"), ("TIP".into(), "".into()));
+  assert_eq!(parse_github_alerts_container_meta("[!TIP this is tip block"), ("".into(), "".into()));
+  assert_eq!(parse_github_alerts_container_meta("[!TIP] this is tip block"), ("TIP".into(), " this is tip block".into()));
+ }
+
   #[test]
   fn test_container_plugin_with_mdx_flow_in_content() {
     let mut root = hast::Node::Root(hast::Root {
@@ -680,6 +811,162 @@ mod tests {
                 children: vec![],
                 position: None,
               })],
+              position: None,
+            })
+          ],
+          position: None,
+        })],
+        position: None,
+      })
+    );
+  }
+
+  #[test]
+  fn test_container_plugin_width_details_title() {
+    let mut root = hast::Node::Root(hast::Root {
+      children: vec![
+        hast::Node::Element(hast::Element {
+          tag_name: "p".into(),
+          properties: vec![],
+          children: vec![hast::Node::Text(hast::Text {
+            value: ":::details Note".into(),
+            position: None,
+          })],
+          position: None,
+        }),
+        hast::Node::Element(hast::Element {
+          tag_name: "p".into(),
+          properties: vec![],
+          children: vec![hast::Node::Text(hast::Text {
+            value: "This is a tip".into(),
+            position: None,
+          })],
+          position: None,
+        }),
+        hast::Node::Element(hast::Element {
+          tag_name: "p".into(),
+          properties: vec![],
+          children: vec![hast::Node::Text(hast::Text {
+            value: ":::".into(),
+            position: None,
+          })],
+          position: None,
+        }),
+      ],
+      position: None,
+    });
+
+    mdx_plugin_container(&mut root);
+
+    assert_eq!(
+      root,
+      hast::Node::Root(hast::Root {
+        children: vec![hast::Node::Element(hast::Element {
+          tag_name: "details".into(),
+          properties: vec![(
+            "className".into(),
+            hast::PropertyValue::SpaceSeparated(vec!["rspress-directive".into(), "details".into()])
+          ),],
+          children: vec![
+            hast::Node::Element(hast::Element {
+              tag_name: "summary".into(),
+              properties: vec![(
+                "className".into(),
+                hast::PropertyValue::SpaceSeparated(vec!["rspress-directive-title".into()])
+              )],
+              children: vec![hast::Node::Text(hast::Text {
+                value: "Note".into(),
+                position: None,
+              })],
+              position: None,
+            }),
+            hast::Node::Element(hast::Element {
+              tag_name: "div".into(),
+              properties: vec![(
+                "className".into(),
+                hast::PropertyValue::SpaceSeparated(vec!["rspress-directive-content".into()])
+              )],
+              children: vec![hast::Node::Element(hast::Element {
+                tag_name: "p".into(),
+                properties: vec![],
+                children: vec![hast::Node::Text(hast::Text {
+                  value: "This is a tip".into(),
+                  position: None,
+                })],
+                position: None,
+              })],
+              position: None,
+            })
+          ],
+          position: None,
+        })],
+        position: None,
+      })
+    );
+  }
+
+  #[test]
+  fn test_container_plugin_with_github_alerts_title() {
+    let mut root = hast::Node::Root(hast::Root {
+      children: vec![hast::Node::Element(hast::Element {
+        tag_name: "blockquote".into(),
+        properties: vec![],
+        children: vec![
+          hast::Node::Text(hast::Text {
+            value: "\n".into(),
+            position: None,
+          }),
+          hast::Node::Element(hast::Element {
+            tag_name: "p".into(),
+            properties: vec![],
+            children: vec![hast::Node::Text(hast::Text {
+              value: "[!TIP]".into(),
+              position: None,
+            })],
+            position: None,
+          }),
+        ],
+        position: None,
+      })],
+      position: None,
+    });
+
+    mdx_plugin_container(&mut root);
+
+    assert_eq!(
+      root,
+      hast::Node::Root(hast::Root {
+        children: vec![hast::Node::Element(hast::Element {
+          tag_name: "div".into(),
+          properties: vec![(
+            "className".into(),
+            hast::PropertyValue::SpaceSeparated(vec!["rspress-directive".into(), "TIP".into()])
+          ),],
+          children: vec![
+            hast::Node::Element(hast::Element {
+              tag_name: "div".into(),
+              properties: vec![(
+                "className".into(),
+                hast::PropertyValue::SpaceSeparated(vec!["rspress-directive-title".into()])
+              )],
+              children: vec![hast::Node::Text(hast::Text {
+                value: "TIP".into(),
+                position: None,
+              })],
+              position: None,
+            }),
+            hast::Node::Element(hast::Element {
+              tag_name: "div".into(),
+              properties: vec![(
+                "className".into(),
+                hast::PropertyValue::SpaceSeparated(vec!["rspress-directive-content".into()])
+              )],
+              children: vec![
+                hast::Node::Text(hast::Text {
+                  value: "\n".into(),
+                  position: None,
+                }),
+              ],
               position: None,
             })
           ],


### PR DESCRIPTION
support github alerts syntax  as `@rspress/plugin-container-syntax`

closed: #25
closed: https://github.com/web-infra-dev/rspress/issues/1424#issue-2535928271