### PR TITLE
chore(CI): specify environment for publish workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -398,6 +398,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    environment: production
     needs:
       - test-linux-x64-gnu-binding
       - test-linux-x64-musl-binding


### PR DESCRIPTION
Specify environment for the publish workflow, because the token was set in the production environment.